### PR TITLE
get remoting agent from nucleus image and add support for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# Jenkins Agent Docker Core
+# Jenkins Agent Core
 
-[![](https://images.microbadger.com/badges/image/dwolla/jenkins-agent-core.svg)](https://microbadger.com/images/dwolla/jenkins-agent-core)
 [![license](https://img.shields.io/github/license/dwolla/jenkins-agent-docker-core.svg?style=flat-square)](https://github.com/Dwolla/jenkins-agent-docker-core/blob/master/LICENSE)
 
-Docker image based on Alpine Linux containing the Jenkins remoting JAR and necessary dependencies. This image is used as a base for subsequent images that bundle additional dependencies for specific types of build jobs.
+Docker images containing the Jenkins remoting JAR and necessary dependencies.

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,3 +1,4 @@
+FROM dwolla/jenkins-agent-nucleus AS nucleus
 FROM openjdk:8-jdk-alpine
 LABEL maintainer="Dwolla Dev <dev+jenkins-agent-core@dwolla.com>"
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/jenkins-agent-docker-core"
@@ -6,7 +7,7 @@ ENV JENKINS_HOME=/home/jenkins \
     JENKINS_AGENT=/usr/share/jenkins \
     AGENT_VERSION=2.62.6
 
-COPY jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=nucleus / /
 
 RUN apk add --update --no-cache \
         bash \
@@ -18,9 +19,6 @@ RUN apk add --update --no-cache \
         py-pip \
     && \
     pip install awscli && \
-    curl --create-dirs -sSLo ${JENKINS_AGENT}/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${AGENT_VERSION}/remoting-${AGENT_VERSION}.jar && \
-    chmod 755 ${JENKINS_AGENT} && \
-    chmod 644 ${JENKINS_AGENT}/agent.jar && \
     adduser -S -h ${JENKINS_HOME} jenkins && \
     chown -R jenkins ${JENKINS_HOME} && \
     chmod 755 /usr/local/bin/jenkins-agent

--- a/alpine/README.md
+++ b/alpine/README.md
@@ -1,0 +1,7 @@
+# Jenkins Agent Docker Core—Alpine
+
+[![](https://images.microbadger.com/badges/image/dwolla/jenkins-agent-core:alpine.svg)](https://microbadger.com/images/dwolla/jenkins-agent-core:alpine)
+[![](https://images.microbadger.com/badges/version/dwolla/jenkins-agent-core:alpine.svg)](https://microbadger.com/images/dwolla/jenkins-agent-core:alpine)
+[![license](https://img.shields.io/github/license/dwolla/jenkins-agent-docker-core.svg?style=flat-square)](https://github.com/Dwolla/jenkins-agent-docker-core/blob/master/LICENSE)
+
+Docker image based on Alpine Linux containing the Jenkins remoting JAR and necessary dependencies. This image is used as a base for subsequent images that bundle additional dependencies for specific types of build jobs.

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,0 +1,54 @@
+FROM dwolla/jenkins-agent-nucleus AS nucleus
+FROM openjdk:8-jre
+LABEL maintainer="Dwolla Dev <dev+jenkins-agent-core@dwolla.com>"
+LABEL org.label-schema.vcs-url="https://github.com/Dwolla/jenkins-agent-docker-core"
+
+ENV JENKINS_HOME=/home/jenkins \
+    JENKINS_AGENT=/usr/share/jenkins \
+    AGENT_VERSION=2.62.6
+
+COPY --from=nucleus / /
+
+WORKDIR ${JENKINS_HOME}
+
+# apt-key loop inspired by https://github.com/nodejs/docker-node/issues/340#issuecomment-321669029
+RUN set -ex && \
+    apt-get update && \
+    apt-get install -y \
+        apt-transport-https \
+        bash \
+        bc \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        make \
+        python \
+        python-pip \
+        zip \
+        && \
+    for key in \
+      58118E89F3A912897C070ADBF76221572C52609D \
+    ; do \
+      apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+      apt-key adv --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" || \
+      apt-key adv --keyserver hkp://ipv4.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+    done && \
+    echo "deb https://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y docker-engine && \
+    pip install \
+        awscli \
+        virtualenv \
+        && \
+    mkdir -p ${JENKINS_HOME} && \
+    useradd --home ${JENKINS_HOME} --system jenkins && \
+    chown -R jenkins ${JENKINS_HOME} && \
+    apt-get clean
+
+USER jenkins
+
+RUN git config --global user.email "dev+jenkins@dwolla.com" && \
+    git config --global user.name "Jenkins Build Agent"
+
+ENTRYPOINT ["jenkins-agent"]

--- a/debian/README.md
+++ b/debian/README.md
@@ -1,0 +1,7 @@
+# Jenkins Agent Docker Core—Debian
+
+[![](https://images.microbadger.com/badges/image/dwolla/jenkins-agent-core:debian.svg)](https://microbadger.com/images/dwolla/jenkins-agent-core:debian)
+[![](https://images.microbadger.com/badges/version/dwolla/jenkins-agent-core:debian.svg)](https://microbadger.com/images/dwolla/jenkins-agent-core:debian)
+[![license](https://img.shields.io/github/license/dwolla/jenkins-agent-docker-core.svg?style=flat-square)](https://github.com/Dwolla/jenkins-agent-docker-core/blob/master/LICENSE)
+
+Docker image based on Debian Linux containing the Jenkins remoting JAR and necessary dependencies. This image is used as a base for subsequent images that bundle additional dependencies for specific types of build jobs.


### PR DESCRIPTION
This will require the Docker Hub setup to change to build two images based on the `Dockerfile`s in `alpine/` and `debian/`.

We'll also need to update the downstream images that currently use `FROM dwolla/jenkins-agent-core` to `FROM dwolla/jenkins-agent-core:alpine`.

This setup allows both the Alpine- and Debian-based variants to use the common Jenkins agent script and JAR from `dwolla/jenkins-agent-nucleus`, including [the extension point I added](https://github.com/Dwolla/jenkins-agent-docker-nucleus/blob/master/jenkins-agent#L48).