### PR TITLE
Switch to AdoptOpenJDK

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -22,7 +22,7 @@ RUN apk -U upgrade \
         make \
         openssh-client \
         python3 \
-	py3-pip \
+        py3-pip \
         py3-virtualenv \
     && \
     pip3 install --upgrade --no-cache-dir \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM dwolla/jenkins-agent-nucleus AS nucleus
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk8:alpine
 LABEL maintainer="Dwolla Dev <dev+jenkins-agent-core@dwolla.com>"
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/jenkins-agent-docker-core"
 
@@ -22,11 +22,11 @@ RUN apk -U upgrade \
         make \
         openssh-client \
         python3 \
+	py3-pip \
+        py3-virtualenv \
     && \
-    pip3 install --upgrade --no-cache-dir pip && \
     pip3 install --upgrade --no-cache-dir \
         awscli \
-        virtualenv \
         && \
     adduser -S -h ${JENKINS_HOME} jenkins && \
     chown -R jenkins ${JENKINS_HOME} && \


### PR DESCRIPTION
Switch to AdoptOpenJDK and fix resulting Python installation issues.