### PR TITLE
remove architecture from build matrix to verify that buildx pushes multi-arch images correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
         temurin_tag:
           - 8u322-b06-jdk
           - 11.0.14.1_1-jdk
-        architecture:
-          - linux/amd64
-          - linux/arm/v8
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: ${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm/v8
           push: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
If this works, we can try to separate them back out in a followup PR.