### PR TITLE
use linux/arm64 to make the ARM images work better with Docker for Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
With the previous config, I was getting this error when trying to pull the images locally:

```
$ docker pull dwolla/jenkins-agent-core:sha-618c2ee-8u322-b06-jdk
sha-618c2ee-8u322-b06-jdk: Pulling from dwolla/jenkins-agent-core
no matching manifest for linux/arm64/v8 in the manifest list entries
```

I could override the platform manually with `--platform linux/arm/v8` but I think it's better to correct it here.