### PR TITLE
set JENKINS_HOME environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG JENKINS_REMOTING_TAG
 FROM jenkins/inbound-agent:$JENKINS_REMOTING_TAG
 LABEL maintainer="Dwolla Dev <dev+jenkins-agent-core@dwolla.com>"
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/jenkins-agent-docker-core"
+ENV JENKINS_HOME=/home/jenkins
 
 COPY build/install-esh.sh /tmp/build/install-esh.sh
 


### PR DESCRIPTION
This was previously set in our [Dwolla/jenkins-agent-nucleus](https://github.com/Dwolla/jenkins-agent-docker-nucleus/blob/main/Dockerfile#L2) image, but it's not set by jenkins/inbound-agent. We use it downstream from Dwolla/jenkins-agent-core, so I think it makes sense to put it back.