### PR TITLE
add Platform team as codeowners

### DIFF
--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,0 +1,1 @@
+*       @Dwolla/platform


### PR DESCRIPTION
I think this will take affect when it is merged - from [github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location): 

`For code owners to receive review requests, the CODEOWNERS file must be on the base branch of the pull request.`

Also, the name of the team is "Platform", but it appears as "platform" in the [URL/UI](https://github.com/orgs/Dwolla/teams/platform), so I specified it as lowercase here.