### PR TITLE
set the default branch configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
 USER jenkins
 
 RUN git config --global user.email "dev+jenkins@dwolla.com" && \
-    git config --global user.name "Jenkins Build Agent"
+    git config --global user.name "Jenkins Build Agent" && \
+    git config --global init.defaultBranch main
 
 ENTRYPOINT ["jenkins-agent"]


### PR DESCRIPTION
this should suppress the warning we see in certain build stages, e.g.:

> ```
> + git init
> hint: Using 'master' as the name for the initial branch. This default branch name
> hint: is subject to change. To configure the initial branch name to use in all
> hint: of your new repositories, which will suppress this warning, call:
> hint:
> hint: 	git config --global init.defaultBranch <name>
> hint:
> hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
> hint: 'development'. The just-created branch can be renamed via this command:
> hint:
> hint: 	git branch -m <name>
> Initialized empty Git repository in /home/jenkins/workspace/job-name/.git/
> ```